### PR TITLE
Move intl-equalizer command inside lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && intl-equalizer && intl-equalizer --fix"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {
@@ -25,6 +25,9 @@
     ],
     "*.json": [
       "prettier --write"
+    ],
+    "messages/*.json": [
+      "yarn lint:locales"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
#### What problem is this solving?
Config intl-equalizer to watch only JSONs inside messages folder, this way we don't have errors about it when trying to commit stuff not related to that

#### How to test it?
- Create the problem for intl-equalizer
  - Add one message to only one language file
- Change any code in react folder
- Try to commit it
- Expect no error on pre-commit about intl-equalizer

> Don't push the previous test commit

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Cmr1OMJ2FN0B2/giphy.gif)
