### PR TITLE
fix: Cannot find name 'Schema'.

### DIFF
--- a/react/typings/gql.d.ts
+++ b/react/typings/gql.d.ts
@@ -11,5 +11,5 @@ declare module '*.graphql' {
 
   const schema: DocumentNode
 
-  export default Schema
+  export default schema
 }


### PR DESCRIPTION
camelcase variable schema throw error "Cannot find name 'Schema'. Did you mean 'schema'"

#### What problem is this solving?

React boilerplate throw an error when start

#### How to test it?
it's a simple camelCase error

#### Screenshots or example usage:
![image](https://user-images.githubusercontent.com/46490801/149576760-9e1c837f-3ca3-4633-9f1a-ac26a0116043.png)

#### Describe alternatives you've considered, if any.
this block is apparently duplicated